### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [ :show, :edit, :update ]
+  before_action :set_item, only: [ :show, :edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -32,6 +32,15 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+      item = Item.find(params[:id])
+    if item.destroy
+      redirect_to root_path
+    else
+       render :index
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,8 @@ class ItemsController < ApplicationController
 
   def destroy
       item = Item.find(params[:id])
-    if item.destroy
+    if item.user_id == current_user.id
+      item.destroy
       redirect_to root_path
     else
        render :index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
       item.destroy
       redirect_to root_path
     else
-       render :index
+      redirect_to items_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
       <% if current_user.id == @item.user_id %>
        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
        <p class="or-text">or</p>
-       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+       <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
        <% else%>
        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
  root to: 'items#index'
- resources :items, only: [:index, :new, :create, :show, :edit, :update]
+ resources :items
 end


### PR DESCRIPTION
#what
出品商品の削除機能実装
#why
商品出品後に、出品者が削除できる様にするため。

#gyazo
#ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/4474c7d7ec5d10914e2f6d524d630955
https://gyazo.com/50307e4fd8d79fb123fdc833f71175f1